### PR TITLE
Prevent eternal hang in clients for failed jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *~
 _trial_temp/
 html
+build
+dist
+twisted_gears.egg-info/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Dustin Sallings <dustin@spy.net>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,3 @@
 Dustin Sallings <dustin@spy.net>
+Ralph Meijer <ralphm@ik.nu>
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include examples *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include examples *.py
+include AUTHORS

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -10,9 +10,9 @@ from twisted.python import util
 
 from gearman import client
 
-def run_test(j):
-    print repr(j)
-    return j
+def run_test(job):
+    print repr(job.data)
+    return job.data
 
 # @defer.inlineCallbacks
 def worker(gearman):

--- a/gearman/client.py
+++ b/gearman/client.py
@@ -21,8 +21,7 @@ class GearmanProtocol(stateful.StatefulProtocol):
     unsolicited = [ WORK_COMPLETE, WORK_FAIL, NOOP,
                     WORK_DATA, WORK_WARNING, WORK_EXCEPTION ]
 
-    def makeConnection(self, transport):
-        stateful.StatefulProtocol.makeConnection(self, transport)
+    def connectionMade(self):
         self.receivingCommand = 0
         self.deferreds = deque()
         self.unsolicited_handlers = set()

--- a/gearman/client.py
+++ b/gearman/client.py
@@ -148,7 +148,7 @@ class GearmanWorker(object):
         f = self.functions[job.function]
         assert f
         try:
-            rv = yield f(job.data)
+            rv = yield f(job)
             if rv is None:
                 rv = ""
             self._send_job_res(WORK_COMPLETE, job, rv)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name = "twisted-gears",
-    version = "0.1",
+    version = "0.2",
     author = "Dustin Sallings",
     author_email = "dustin@spy.net",
     url = "http://bleu.west.spy.net/~dustin/",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""
+TwistedGears installation script
+"""
+from setuptools import setup
+
+setup(
+    name = "twisted-gears",
+    version = "0.1",
+    author = "Dustin Sallings",
+    author_email = "dustin@spy.net",
+    url = "http://bleu.west.spy.net/~dustin/",
+    description = "A twisted interface to gearman.",
+    license="Unknown",
+    packages = ["gearman"],
+    classifiers = [
+        "Framework :: Twisted",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Topic :: Communications",
+        "Topic :: Software Development :: Libraries :: Python Modules"
+        ]
+    )


### PR DESCRIPTION
The response for a failed job has an erroneous NULL at the end of the payload, causing clients that are still waiting for the result (synchronously) to hang indefinitely. The last commit fixes this by generalizing how parameters are encoded in outgoing packets.

The other commits are packaging, a minor fix for protocol initialization to make it easier to override and a change that passes the whole `_GearmanJob` instance to the handler, instead of just the payload. The latter allows for having access to the job's function name and the handle. For now, I use this for logging purposes, but they could later be used to implement sending incremental results.
